### PR TITLE
feat: upgrade to Astro v6.0.2 with built-in Font API

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,10 +3,45 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import AutoImport from "astro-auto-import";
-import { defineConfig, sharpImageService } from "astro/config";
+import { defineConfig, sharpImageService, fontProviders } from "astro/config";
 import remarkCollapse from "remark-collapse";
 import remarkToc from "remark-toc";
 import config from "./src/config/config.json";
+import theme from "./src/config/theme.json";
+
+// Helper to parse font string format: "FontName:wght@400;500;600;700"
+function parseFontString(fontStr) {
+  const [name, weightPart] = fontStr.split(":");
+  let weights = [400]; // default weight
+
+  if (weightPart) {
+    // Extract weights from wght@400;500;600 format
+    const weightMatch = weightPart.match(/wght@?([\d;]+)/);
+    if (weightMatch) {
+      weights = weightMatch[1].split(";").map((w) => parseInt(w, 10));
+    }
+  }
+
+  return { name, weights };
+}
+
+// Build fonts configuration from theme.json
+const fontsConfig = Object.entries(theme.fonts.font_family)
+  .filter(([key]) => !key.includes("_type")) // Filter out type entries
+  .map(([key, fontStr]) => {
+    const { name, weights } = parseFontString(fontStr);
+    const typeKey = `${key}_type`;
+    const fallback = theme.fonts.font_family[typeKey] || "sans-serif";
+
+    return {
+      name,
+      cssVariable: `--font-${key}`,
+      provider: fontProviders.google(),
+      weights,
+      display: "swap",
+      fallbacks: [fallback],
+    };
+  });
 
 // https://astro.build/config
 export default defineConfig({
@@ -15,6 +50,7 @@ export default defineConfig({
   trailingSlash: config.site.trailing_slash ? "always" : "never",
   image: { service: sharpImageService() },
   vite: { plugins: [tailwindcss()] },
+  fonts: fontsConfig,
   integrations: [
     react(),
     sitemap(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bigspring-light-astro",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "astro personal blog theme",
   "author": "themefisher",
   "license": "MIT",
@@ -15,23 +15,22 @@
     "preview:cf-workers": "npm run build && wrangler dev"
   },
   "dependencies": {
-    "@astrojs/check": "0.9.7-beta.1",
-    "@astrojs/mdx": "5.0.0-beta.9",
-    "@astrojs/react": "5.0.0-beta.3",
-    "@astrojs/sitemap": "3.7.0",
+    "@astrojs/check": "0.9.7",
+    "@astrojs/mdx": "5.0.0",
+    "@astrojs/react": "5.0.0",
+    "@astrojs/sitemap": "3.7.1",
     "@digi4care/astro-google-tagmanager": "^1.6.0",
     "@justinribeiro/lite-youtube": "^1.9.0",
     "@tailwindcss/vite": "^4.2.1",
-    "astro": "6.0.0-beta.17",
+    "astro": "6.0.2",
     "astro-auto-import": "^0.5.1",
-    "astro-font": "^1.1.0",
-    "astro-swiper": "^2.1.1",
+    "astro-swiper": "^2.2.1",
     "date-fns": "^4.1.0",
     "github-slugger": "^2.0.0",
-    "marked": "^17.0.3",
+    "marked": "^17.0.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-icons": "^5.5.0",
+    "react-icons": "^5.6.0",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
     "sharp": "0.34.5",
@@ -40,13 +39,15 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
+    "@types/node": "25.4.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "19.2.3",
+    "eslint": "^10.0.3",
     "prettier": "^3.8.1",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.2.1",
     "typescript": "^5.9.3",
-    "wrangler": "^4"
+    "wrangler": "^4.72.0"
   }
 }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,18 +10,13 @@ import {
   GoogleTagmanager,
   GoogleTagmanagerNoscript,
 } from "@digi4care/astro-google-tagmanager";
-import { AstroFont } from "astro-font";
+import { Font } from "astro:assets";
 import { ClientRouter } from "astro:transitions";
 
-// font families
-const pf = theme.fonts.font_family.primary;
-
-let fontPrimary;
-if (theme.fonts.font_family.primary) {
-  fontPrimary = theme.fonts.font_family.primary
-    .replace(/\+/g, " ")
-    .replace(/:[ital,]*[ital@]*[wght@]*[0-9,;.]+/gi, "");
-}
+// font families - extract font names for Font component (filter out type keys)
+const fontEntries = Object.entries(theme.fonts.font_family).filter(
+  ([key]) => !key.includes("_type"),
+);
 
 // types for frontmatters
 export interface Props {
@@ -65,20 +60,13 @@ const { title, meta_title, description, image, noindex, canonical } =
     <meta name="generator" content={Astro.generator} />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 
-    <!-- google font css -->
-    <AstroFont
-      config={[
-        {
-          src: [],
-          preload: false,
-          display: "swap",
-          name: fontPrimary!,
-          fallback: "sans-serif",
-          cssVariable: "font-primary",
-          googleFontsURL: `https://fonts.googleapis.com/css2?family=${pf}&display=swap`,
-        },
-      ]}
-    />
+    <!-- google font css - Astro 6 built-in Font API -->
+    {
+      fontEntries.map(([key]) => {
+        const cssVar = `--font-${key}` as any;
+        return <Font cssVariable={cssVar} preload />;
+      })
+    }
 
     <!-- responsive meta -->
     <meta


### PR DESCRIPTION
- Update Astro to v6.0.2 (stable release)
- Replace astro-font package with Astro's built-in Font API
- Add font parsing configuration to astro.config.mjs
- Simplify font handling in Base.astro layout
- Update all dependencies to stable versions
- Remove astro-font dependency

Follows the changes from zeon-studio/astroplate@c04ffb8